### PR TITLE
Fix for json for github

### DIFF
--- a/main.py
+++ b/main.py
@@ -83,7 +83,10 @@ def update():
     return "Unrecognized source IP"
 
   jd = json.JSONDecoder()
-  payload = jd.decode(request.form['payload'])
+  if 'payload' in request.form:
+    payload = jd.decode(request.form['payload'])
+  else:
+    payload = jd.decode(request.get_data())
   info = decoder(payload)
   state[info['name']] = info
   log(info)


### PR DESCRIPTION
Previously only x-www-form-urlencoded worked for Python 2.7.3 at least. This works for both json and www-form. I've tested this after my fix.
